### PR TITLE
Added a YulpDeployer contract to make deploying Yul+ contracts abstracted.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ interface SimpleStore {
 }
 ```
 
-Lastly, here is the test file that deploys the Yul+ contract and tests the `get()` function. You can see that this file imports the `SimpleStore.sol` interface as well as the `YulpDeployer.sol` contract. To deploy the contract, simply create a new instance of `YulpDeployer` and call `yulpDeployer.deployContract(fileName)` method, passing in the file name of the contract you want to deploy. In this example, we pass in `SimpleStore` to deploy the `SimpleStore.yulp` contract. This function returns the address that the contract was deployed to, which we can use to initialize the SimpleStore interface. With that, your Yul+ contract can now be used within Foundry like any other Solidity contract!
+Lastly, here is the test file that deploys the Yul+ contract and tests the `get()` function. You can see that this file imports the `SimpleStore.sol` interface as well as the `YulpDeployer.sol` contract. To deploy the contract, simply create a new instance of `YulpDeployer` and call `yulpDeployer.deployContract(fileName)` method, passing in the file name of the contract you want to deploy. In this example, we pass in `SimpleStore` to deploy the `SimpleStore.yulp` contract. This function returns the address that the contract was deployed to, which we can use to initialize the SimpleStore interface. With that, your Yul+ contract can now be used within Foundry like any other Solidity contract. To test any Yul+ contract deployed with YulpDeployer, simply run `forge test --ffi`. You can use this command with any additional flags. For example: `forge test --ffi -f <url> -vvvv`.
 
 ### SimpleStore Test
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,110 @@
 # Foundry-Yulp-Template
 
-A Template Foundry Repository to make your Yul+ Contracts work with Foundry.
+A Foundry Template to compile and test your Yul+ Contracts.
 
 ## Installation / Setup
 
-First install my Yul+ toolchain which is need to compile the Yul+ contracts into bytecode
+Installation is only two easy steps. First, clone this repo.
+
+```
+https://github.com/ControlCplusControlV/Foundry-Yulp-Template.git
+```
+
+Next, make sure you have [Yul-Log](https://github.com/ControlCplusControlV/Yul-Log) installed. Yul-Log is a Yul/Yul+ toolchain that enables Yul+ contracts to be compiled into bytecode.
 
 ```
 npm i -g yul-log  
 ```
 
-From here you can compile your Yul+ contracts with
+Now you are all set up and ready to go!
 
+<br>
+
+## Compiling/Testing Yul+ Contracts
+
+In order to compile and test Yul+ contracts with Foundry, there are two simple steps. First make sure to put your `.yulp` files in the directory named `Yul+ Contracts`. This way, yul-log will know where to look when compiling your contracts.
+
+Next, you will need to create an interface for your contract. This will allow Foundry to interact with your Yul+ contract, enabling the full testing capabilities that Foundry has to offer.
+
+Once you have an interface set up for your contract, you are ready to use the YulpDeployer! 
+
+The YulpDeployer is a pre-built contract that takes a filename, deploys the corresponding Yul+ contract and returns the address that the bytecode was deployed to. If you want, [you can check out the YulpDeployer contract here](). 
+
+From here, you can simply initalize a new contract through the interface you made for the Yul+ contract and pass in the address of the deployed bytecode. Now your Yul+ contract is fully functional within Foundry!
+
+<br>
+
+## Example
+Here is a quick example of how to setup and deploy a SimpleStore contract written in Yul+.
+
+Here is the `SimpleStore.yulp` file, which should be within the `Yul+ Contracts` directory.
+
+### SimpleStore.yulp
+```js
+object "SimpleStore" {
+  code {
+    datacopy(0, dataoffset("Runtime"), datasize("Runtime"))
+    return(0, datasize("Runtime"))
+  }
+  object "Runtime" {
+    code {
+      calldatacopy(0, 0, 36) // write calldata to memory
+
+      mstruct StoreCalldata( // Custom addressable calldata structure
+        sig: 4,
+        val: 32
+      )
+
+      switch StoreCalldata.sig(0) // select signature from memory (at position 0)
+
+      case sig"function store(uint256 val)" { // new signature method
+        sstore(0, StoreCalldata.val(0)) // sstore calldata value
+        log2(0, 0, topic"event Store(uint256 value)", StoreCalldata.val(0))
+      }
+
+      case sig"function get() returns (uint256)" {
+        mstore(100, sload(0))
+        return (100, 32)
+      }
+    }
+  }
+}
 ```
-yul-log
+
+Next, here is an example interface for the SimpleStore contract.
+
+### SimpleStore Interface
+
+```js
+
+interface SimpleStore {
+    function store(uint256 val) external;
+    function get() external returns (uint256);
+}
 ```
 
-then you can test them via
+Lastly, here is the test file that deploys the Yul+ contract and tests the `get()` function. You can see that this file imports the `SimpleStore.sol` interface as well as the `YulpDeployer.sol` contract. To deploy the contract, simply create a new instance of `YulpDeployer` and call `yulpDeployer.deployContract(fileName)` method, passing in the file name of the contract you want to deploy. In this example, we pass in `SimpleStore` to deploy the `SimpleStore.yulp` contract. This function returns the address that the contract was deployed to, which we can use to initialize the SimpleStore interface. With that, your Yul+ contract can now be used within Foundry like any other Solidity contract!
 
-```
-forge build
-forge test --ffi
-```
+### SimpleStore Test
 
-then install this template via
+```js
+import "../../lib/ds-test/test.sol";
+import "../SimpleStore.sol";
+import "../../lib/YulpDeployer.sol";
 
-```
-forge install ControlCplusControlV/Foundry-Yulp-Template
-```
-## Writing Tests
 
-For each project it's pretty simple (given you have the knowledge to write Yul), just import the bytecode and deploy the contract at the start of each test. From there you can interact with them like normal. To do that just use these 2 functions in each test, in this case `SimpleStore` is the name of the contract being tests
+contract SimpleStoreTest is DSTest {
+    YulpDeployer yulpDeployer = new YulpDeployer();
 
-```solidity=
-    function deployContract(bytes memory code) internal returns (address addr) {
-        assembly {
-            addr := create(0, add(code, 0x20), mload(code))
-            if iszero(addr) {
-                revert (0, 0)
-            }
-        }
+    SimpleStore simpleStore;
+
+    function setUp() public {
+        simpleStore = SimpleStore(yulpDeployer.deployContract("SimpleStore"));
     }
 
-    function getSimpleStoreBytecode() internal returns (bytes memory) {
-        CheatCodes cheatCodes = CheatCodes(HEVM_ADDRESS);
-
-        string[] memory cmds = new string[](3);
-        cmds[0] = "yul-log";
-        cmds[1] = "SimpleStore";
-        cmds[2] = "bytecode";
-
-        bytes memory bytecode = abi.decode(cheatCodes.ffi(cmds), (bytes));
-        return bytecode;
+    function testGet() public {
+        simpleStore.get();
     }
+}
 ```
+

--- a/src/Contract.sol
+++ b/src/Contract.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.12;
-
-contract Contract {}

--- a/src/SimpleStore.sol
+++ b/src/SimpleStore.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface SimpleStore {
+    function store(uint256 val) external;
+
+    function get() external returns (uint256);
+}

--- a/src/test/SimpleStore.t.sol
+++ b/src/test/SimpleStore.t.sol
@@ -2,49 +2,19 @@
 pragma solidity >=0.8.0;
 
 import "./lib/test.sol";
-
-interface CheatCodes {
-    function ffi(string[] calldata) external returns (bytes memory);
-}
-
-interface SimpleStore {
-    function store(uint256 val) external;
-    function get() external returns (uint256);
-}
+import "../SimpleStore.sol";
+import "./lib/YulpDeployer.sol";
 
 contract SimpleStoreTest is DSTest {
+    YulpDeployer yulpDeployer = new YulpDeployer();
 
-    function test_simple_store() public {
-        bytes memory bytecode = getSimpleStoreBytecode();
-        address deployed_contract = deployContract(bytecode);
-        SimpleStore(deployed_contract).store(1000);
-        uint256 stored_val = SimpleStore(deployed_contract).get();
+    SimpleStore simpleStore;
 
-        assertEq(1000, stored_val, "Contract Failed to Store Value");
-        
-
+    function setUp() public {
+        simpleStore = SimpleStore(yulpDeployer.deployContract("SimpleStore"));
     }
 
-    // ******** Internal functions ********
-
-    function deployContract(bytes memory code) internal returns (address addr) {
-        assembly {
-            addr := create(0, add(code, 0x20), mload(code))
-            if iszero(addr) {
-                revert (0, 0)
-            }
-        }
-    }
-
-    function getSimpleStoreBytecode() internal returns (bytes memory) {
-        CheatCodes cheatCodes = CheatCodes(HEVM_ADDRESS);
-
-        string[] memory cmds = new string[](3);
-        cmds[0] = "yul-log";
-        cmds[1] = "SimpleStore";
-        cmds[2] = "bytecode";
-
-        bytes memory bytecode = abi.decode(cheatCodes.ffi(cmds), (bytes));
-        return bytecode;
+    function testGet() public {
+        simpleStore.get();
     }
 }

--- a/src/test/lib/YulpDeployer.sol
+++ b/src/test/lib/YulpDeployer.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.12;
+
+///@notice This cheat codes interface is named _CheatCodes so you can use the CheatCodes interface in other testing files without errors
+interface _CheatCodes {
+    function ffi(string[] calldata) external returns (bytes memory);
+}
+
+contract YulpDeployer {
+    address constant HEVM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @notice Initializes cheat codes in order to use ffi to compile Yul and Yul+ contracts
+    _CheatCodes cheatCodes = _CheatCodes(HEVM_ADDRESS);
+
+    ///@notice Compiles a Yul or Yul+ contract and returns the address that the contract was deployeod to
+    ///@notice If deployment fails, an error will be thrown
+    ///@param fileName - The file name of the Yul or Yul+ contract. For example, the file name for "SimpleStore.yulp" is "SimpleStore"
+    ///@return deployedAddress - The address that the contract was deployed to
+    function deployContract(string memory fileName) public returns (address) {
+        ///@notice create a list of strings with the commands necessary to compile Yul and Yul+ contracts
+        string[] memory cmds = new string[](3);
+        cmds[0] = "yul-log";
+        cmds[1] = fileName;
+        cmds[2] = "bytecode";
+
+        ///@notice compile the Yul/Yul+ contract and return the bytecode
+        bytes memory bytecode = abi.decode(cheatCodes.ffi(cmds), (bytes));
+
+        ///@notice deploy the bytecode with the create instruction
+        address deployedAddress;
+        assembly {
+            deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        ///@notice check that the deployment was successful
+        require(
+            deployedAddress != address(0),
+            "YulpDeployer could not deploy contract"
+        );
+
+        ///@notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
+}


### PR DESCRIPTION
I created a contracted called YulpDeployer to make deploying Yul+ contracts more abstracted.  I also updated the readme to walk through how to use the YulpDeployer contract.

To deploy the Yul+ contract you can create a new instance of YulpDeployer in your test contract. Then you can call the `yulpDeployer.deployContract(fileName)` method which takes a the file name of the Yul+ contract as a paramater. Under the hood, the `deployContract` compiles the Yul+ code and deploys the bytecode, returning the address that the code was deployed to. Because this function returns the deployment address, you can initialize your contract by creating a new instance of the interface you built, and passing in the deployed address. From there you can use the contract like any other contract in Foundry. 

Here is what an example of a test file looks like using the `YulpDeployer` contract.

```js
import "../../lib/ds-test/test.sol";
import "../SimpleStore.sol";
import "../../lib/YulpDeployer.sol";


contract SimpleStoreTest is DSTest {
    YulpDeployer yulpDeployer = new YulpDeployer();

    SimpleStore simpleStore;

    function setUp() public {
        simpleStore = SimpleStore(yulpDeployer.deployContract("SimpleStore"));
    }

    function testGet() public {
        simpleStore.get();
    }
}
```